### PR TITLE
Added test for regex entity feature and auto higlighting of sys entities

### DIFF
--- a/api/modules/agent/tools/parseText.agent.tool.js
+++ b/api/modules/agent/tools/parseText.agent.tool.js
@@ -42,7 +42,6 @@ const getDucklingParse = (textToParse, timezone, language, ducklingService, call
         lang: language,
         tz: timezone
     };
-
     Wreck.post(ducklingService + '/parse', {
         payload: Querystring.stringify(ducklingPayload),
         headers: {
@@ -112,7 +111,7 @@ const castSysEntities = (parseResult, spacyPretrainedEntities, ducklingDimension
                 entity: entity.name,
                 extractor: 'regex',
                 start: entity.start,
-                value: { value: entity.entityValue }
+                value: { value: entity.entityValue, original: entity.resolvedRegex }
             };
         }
         return tmpEntity;

--- a/api/test/api/preCreatedAgent.json
+++ b/api/test/api/preCreatedAgent.json
@@ -9,7 +9,7 @@
     "Sorry, can you rephrase that?",
     "I'm still learning to speak with humans, can you rephrase that?"
   ],
-  "domainClassifierThreshold": 0.6,
+  "domainClassifierThreshold": 0.5,
   "webhook": {
     "webhookUrl": "http://localhost:3000/agent/{{agent.id}}",
     "webhookVerb": "GET",
@@ -50,6 +50,22 @@
           ]
         }
       ]
+    },
+    {
+      "uiColor": "#e91e62",
+      "entityName": "Test Regex Entity",
+      "type": "regex",
+      "regex": null,
+      "examples": [
+        {
+          "value": "regex",
+          "synonyms": [
+            "regex",
+            "regex2",
+            "regex3"
+          ]
+        }
+      ]
     }
   ],
   "domains": [
@@ -57,7 +73,7 @@
       "enabled": true,
       "domainName": "Test Domain",
       "model": "Test Domain_a24ef9cb-88f6-3da5-a0df-bdec39bd3069",
-      "intentThreshold": 0.7,
+      "intentThreshold": 0.5,
       "intents": [
         {
           "intentName": "Test Intent",
@@ -77,6 +93,28 @@
             },
             {
               "userSays": "I need to find my laptop",
+              "entities": [
+                {
+                  "end": 24,
+                  "value": "laptop",
+                  "start": 18,
+                  "entity": "Test Entity"
+                }
+              ]
+            },
+            {
+              "userSays": "I need to find my laptop please",
+              "entities": [
+                {
+                  "end": 24,
+                  "value": "laptop",
+                  "start": 18,
+                  "entity": "Test Entity"
+                }
+              ]
+            },
+            {
+              "userSays": "I specifically need to find my laptop please",
               "entities": [
                 {
                   "end": 24,
@@ -181,6 +219,46 @@
               "entities": []
             }
           ]
+        },
+        {
+          "intentName": "Test Regex Intent",
+          "useWebhook": false,
+          "usePostFormat": false,
+          "examples": [
+            {
+              "userSays": "Here's my regex",
+              "entities": []
+            },
+            {
+              "userSays": "Here's my regex2",
+              "entities": []
+            },
+            {
+              "userSays": "Do you need my regex3?",
+              "entities": []
+            },
+            {
+              "userSays": "This is my regex",
+              "entities": []
+            }
+          ],
+          "scenario": {
+            "scenarioName": "Test Regex Intent",
+            "slots": [
+              {
+                "entity": "Test Regex Entity",
+                "isList": false,
+                "slotName": "searchedRegex",
+                "isRequired": true,
+                "textPrompts": [
+                  "What are you looking for?"
+                ]
+              }
+            ],
+            "intentResponses": [
+              "Your regex is {{slots.searchedRegex.value}}."
+            ]
+          }
         }
       ]
     }

--- a/ui/app/containers/IntentPage/Components/AgentEntities.js
+++ b/ui/app/containers/IntentPage/Components/AgentEntities.js
@@ -38,18 +38,18 @@ export function AgentEntities(props) {
         </NavItem>
       );
     });
-    
-  if (props.createEntity) {
     items = Immutable([entitiesItems])
-      .concat(<NavItem key="dividerSysEntities" divider />)
-      .concat(systemEntities);
-      //.concat(<NavItem key="dividerNewEntity" divider />)
-      //.concat(newEntity);
-  } else {
-    items = Immutable([entitiesItems])
-      .concat(<NavItem key="divider" divider />)
-      .concat(systemEntities);;
-  }
+  // if (props.createEntity) {
+  //   items = Immutable([entitiesItems])
+  //     //.concat(<NavItem key="dividerSysEntities" divider />)
+  //     //.concat(systemEntities);
+  //     //.concat(<NavItem key="dividerNewEntity" divider />)
+  //     //.concat(newEntity);
+  // } else {
+  //   items = Immutable([entitiesItems])
+  //     .concat(<NavItem key="divider" divider />)
+  //     .concat(systemEntities);;
+  // }
 
   return (
     <Dropdown className="dropdown-entity-selector" trigger={<span id={`userSayingDropdown_${props.index}`}></span>} options={{ belowOrigin: true }}>

--- a/ui/app/containers/IntentPage/actions.js
+++ b/ui/app/containers/IntentPage/actions.js
@@ -27,7 +27,9 @@ import {
   LOAD_POSTFORMAT_SUCCESS,
   CHANGE_POSTFORMAT_DATA,
   SORT_SLOTS,
-  CHANGE_SLOT_AGENT
+  CHANGE_SLOT_AGENT,
+  FIND_SYS_ENTITES,
+  RELOAD_INTENT_WITH_SYS_ENTITIES
 } from './constants';
 
 export function changeIntentData(payload) {
@@ -156,9 +158,25 @@ export function loadIntentSuccess(intent) {
   };
 }
 
+export function loadSysEntitiesSucess(intent) {
+  return {
+    type: RELOAD_INTENT_WITH_SYS_ENTITIES,
+    intent,
+  };
+}
+
+
 export function loadIntent(id) {
   return {
     type: LOAD_INTENT,
+    apiCall: true,
+    id,
+  };
+}
+
+export function findSysEntities(id) {
+  return {
+    type: FIND_SYS_ENTITES,
     apiCall: true,
     id,
   };

--- a/ui/app/containers/IntentPage/constants.js
+++ b/ui/app/containers/IntentPage/constants.js
@@ -1,6 +1,7 @@
 export const CHANGE_INTENT_DATA = 'IntentPage/CHANGE_INTENT_DATA';
 export const CHANGE_WEBHOOK_DATA = 'IntentPage/CHANGE_WEBHOOK_DATA';
 export const CHANGE_POSTFORMAT_DATA = 'IntentPage/CHANGE_POSTFORMAT_DATA';
+export const FIND_SYS_ENTITES = 'IntentPage/FIND_SYS_ENTITIES';
 export const RESET_INTENT_DATA = 'IntentPage/RESET_INTENT_DATA';
 export const TAG_ENTITY = 'IntentPage/TAG_ENTITY';
 export const UNTAG_ENTITY = 'IntentPage/UNTAG_ENTITY';
@@ -16,6 +17,7 @@ export const ADD_SLOT = 'IntentPage/ADD_SLOT';
 export const SET_WINDOW_SELECTION = 'IntentPage/SET_WINDOW_SELECTION';
 export const LOAD_INTENT = 'IntentPage/LOAD_INTENT';
 export const LOAD_INTENT_SUCCESS = 'IntentPage/LOAD_INTENT_SUCCESS';
+export const RELOAD_INTENT_WITH_SYS_ENTITIES = 'IntentPage/RELOAD_INTENT_WITH_SYS_ENTITIES'
 export const LOAD_INTENT_ERROR = 'IntentPage/LOAD_INTENT_ERROR';
 export const LOAD_SCENARIO = 'IntentPage/LOAD_SCENARIO';
 export const LOAD_SCENARIO_SUCCESS = 'IntentPage/LOAD_SCENARIO_SUCCESS';

--- a/ui/app/containers/IntentPage/index.js
+++ b/ui/app/containers/IntentPage/index.js
@@ -67,7 +67,8 @@ import {
   loadWebhook,
   loadPostFormat,
   sortSlots,
-  changeSlotAgent
+  changeSlotAgent,
+  findSysEntities
 } from './actions';
 import AvailableSlots from './Components/AvailableSlots';
 import Responses from './Components/Responses';
@@ -153,6 +154,7 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
 
   state = {
     entityTagged: false,
+    findNewSysEntities: false,
     userExamplesPage: 0,
     userExamplesPages: 0,
     userExamplesShown: [],
@@ -238,7 +240,14 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
 
   componentDidUpdate(prevProps, prevState, prevContext) {
     //If an example is added or removed then update the table to add/remove the new example
-    if (prevProps.intent.examples.length !== this.props.intent.examples.length) {
+    if (!_.isEqual(prevProps.scenarioData.slots,this.props.scenarioData.slots) || !_.isEqual(prevProps.intent.examples,this.props.intent.examples)){
+      this.setState({findNewSysEntities: true});
+      this.props.onFindSysEntities(this.props.currentAgent.id);
+    }
+    
+    if (prevProps.intent.examples.length !== this.props.intent.examples.length ) {
+      this.setState({findNewSysEntities: true});
+      this.props.onFindSysEntities(this.props.currentAgent.id);
       if (prevProps.intent.examples.length < this.props.intent.examples.length) {
         this.setState({
           userExamplesPage: 0,
@@ -288,6 +297,12 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
     if (this.state.entityTagged) {
       this.setState({
         entityTagged: false,
+        userExamplesShown: this.props.intent.examples.slice(this.state.userExamplesPage, this.props.defaultUserExamplesPageSize)
+      });
+    }
+    if (this.state.findNewSysEntities) {
+      this.setState({
+        findNewSysEntities: false,
         userExamplesShown: this.props.intent.examples.slice(this.state.userExamplesPage, this.props.defaultUserExamplesPageSize)
       });
     }
@@ -840,6 +855,7 @@ IntentPage.propTypes = {
   onDeleteTextPrompt: React.PropTypes.func,
   onRemoveSlot: React.PropTypes.func,
   onAddSlot: React.PropTypes.func,
+  onFindSysEntities: React.PropTypes.func,
   onSortSlots: React.PropTypes.func,
   currentAgent: React.PropTypes.oneOfType([
     React.PropTypes.object,
@@ -907,6 +923,9 @@ export function mapDispatchToProps(dispatch) {
     onAddSlot: (slot) => {
       dispatch(addSlot(slot));
     },
+    onFindSysEntities: (agentId) =>{
+      dispatch(findSysEntities(agentId))
+    },
     onTagEntity: (userSays, entity) => {
       dispatch(dispatch(resetStatusFlags()));
       dispatch(tagEntity({ userSays, entity }));
@@ -959,8 +978,8 @@ export function mapDispatchToProps(dispatch) {
       dispatch(setWindowSelection(selection));
     },
     onEditMode: (props) => {
-      dispatch(loadIntent(props.params.id));
       dispatch(loadScenario(props.params.id));
+      dispatch(loadIntent(props.params.id));
       try {
         dispatch(loadWebhook(props.params.id));
       }

--- a/ui/app/containers/IntentPage/reducer.js
+++ b/ui/app/containers/IntentPage/reducer.js
@@ -11,6 +11,7 @@ import {
   LOAD_INTENT,
   LOAD_INTENT_ERROR,
   LOAD_INTENT_SUCCESS,
+  RELOAD_INTENT_WITH_SYS_ENTITIES,
   LOAD_SCENARIO,
   LOAD_SCENARIO_ERROR,
   LOAD_SCENARIO_SUCCESS,
@@ -305,6 +306,11 @@ function intentReducer(state = initialState, action) {
         .set('loading', false)
         .set('error', false)
         .set('oldIntent', action.intent)
+        .set('intentData', action.intent);
+    case RELOAD_INTENT_WITH_SYS_ENTITIES:
+        return state
+        .set('loading', false)
+        .set('error', false)
         .set('intentData', action.intent);
     case LOAD_INTENT_ERROR:
       return state


### PR DESCRIPTION
Here is the implementation of auto higlighting for sys entities, things to notice : 
- sys entities cannot be highlighted in the user says anymore (this does not affect the training anyway, and user will thus have direct result of parsing process)
- If agent is never trained, we can't auto highlight sys entities (spacy entities need a train agent to be found by rasa for now)
- We may have to create a generic agent / emebed it in image ? Creating a new endpoint for such action that would only perform duckling and spacy parsing might be a good idea?
- Tests have been added to check regex entity feature (related to  #231 )


